### PR TITLE
Update Role to include Deployments

### DIFF
--- a/charts/smk-app-deploy/templates/smk-app-roles4sa.yaml
+++ b/charts/smk-app-deploy/templates/smk-app-roles4sa.yaml
@@ -67,6 +67,7 @@ rules:
       - apps.openshift.io
     resources:
       - deployments
+      - deploymentconfigs
     verbs:
       - create
       - delete


### PR DESCRIPTION
This addresses a deploy failure caused by the service account not having authorization to update Deployments.

This tidies the Role template in smk-init-helm-chart, copies it into smk-app-deploy, and amends it to be able to update both Deployments and DeploymentConfigs.